### PR TITLE
Fix dead CodeNet links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ to uncompress and untar. The directory structure and how the code samples are or
 The 4 benchmark datasets, Project_CodeNet_C++1000, Project_CodeNet_C++1400,
 Project_CodeNet_Python800, and Project_CodeNet_Java250 are included in the
 full dataset and are available separately in the "Archive Dataset File" column of the table in the "Get this Dataset" 
-section in our [data repository](https://developer.ibm.com/technologies/artificial-intelligence/data/project-codenet/). 
+section in our [data repository](https://developer.ibm.com/exchanges/data/all/project-codenet/). 
 They can be used for code classification and code similarity research as a replacement of or in addition to the dataset [POJ-104](https://sites.google.com/site/treebasedcnn/).
 
-To expedite AI for code research using graph neural networks, we have included the simplified parse tree (SPT) representation of the code samples for each benchmark dataset. They are available in the "Archive SPT File" column of the table in the "Get this Dataset" section in our [data repository](https://developer.ibm.com/technologies/artificial-intelligence/data/project-codenet/).
+To expedite AI for code research using graph neural networks, we have included the simplified parse tree (SPT) representation of the code samples for each benchmark dataset. They are available in the "Archive SPT File" column of the table in the "Get this Dataset" section in our [data repository](https://developer.ibm.com/exchanges/data/all/project-codenet/).
 
 ## Dataset overview
 


### PR DESCRIPTION
Some users are having a hard time to find the correct codenet link since 2 of the links in the readme is broken. Update it to the latest codenet link in ibm developer.